### PR TITLE
feat(deps-dev): upgrade iconoir 5.3.1 -> 5.3.2

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 1188 total icons
+> 1189 total icons
 
 ## Icons
 
@@ -409,6 +409,7 @@
 - Facebook
 - Facetime
 - Farm
+- FastArrowBottom
 - FastArrowDownBox
 - FastArrowDown
 - FastArrowLeftBox

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "gh-pages": "^4.0.0",
-    "iconoir": "5.3.1",
+    "iconoir": "5.3.2",
     "rollup": "^2.79.1",
     "svelte": "^3.52.0",
     "svelte-check": "^2.9.2",

--- a/test/Icons.test.svelte
+++ b/test/Icons.test.svelte
@@ -6,6 +6,7 @@
     Fishing,
     AppleWallet,
     Bed,
+    FastArrowBottom,
   } from "../lib";
   import AddPage from "../lib/AddPage.svelte";
 </script>
@@ -17,3 +18,4 @@
 <AddPage width="30" />
 <AppleWallet fill="red" />
 <Bed />
+<FastArrowBottom />

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,10 +522,10 @@ html-minifier@^4.0.0:
     relateurl "^0.2.7"
     uglify-js "^3.5.1"
 
-iconoir@5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-5.3.1.tgz#fa218841308632baecedc62bd757b936b5663d85"
-  integrity sha512-G7wF7zQzruIIbx9yZdyBDprF0IW31GhjrSxphzMZGPAiHMkxeL/mEpjDoGtkozd1eySd4pE5gonG75EnQEc9Mg==
+iconoir@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-5.3.2.tgz#bd74a542bc499282c067740076f76d1153f4d4df"
+  integrity sha512-om9zHIRaoRs4XUXq11+/RB7lucY8eiz2nX1+DV0VjefMDAlncKctygz6Z/11lQDkISuyaBcbYDpJQvFcaEGvdg==
 
 import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
- upgrade `iconoir` to [v5.3.2](https://github.com/iconoir-icons/iconoir/releases/tag/v5.3.2) (net +1 icon, 22 icons optimized)