### PR TITLE
feat(deps-dev): upgrade `iconoir` 5.3.2 -> 5.4.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 1189 total icons
+> 1210 total icons
 
 ## Icons
 
@@ -89,6 +89,10 @@
 - Archive
 - AreaSearch
 - ArrowArchery
+- ArrowBlCircled
+- ArrowBlSquare
+- ArrowBrCircled
+- ArrowBrSquare
 - ArrowDownCircled
 - ArrowDown
 - ArrowLeftCircled
@@ -97,6 +101,10 @@
 - ArrowRight
 - ArrowSeparateVertical
 - ArrowSeparate
+- ArrowTlCircled
+- ArrowTlSquare
+- ArrowTrCircled
+- ArrowTrSquare
 - ArrowUnionVertical
 - ArrowUnion
 - ArrowUpCircled
@@ -319,6 +327,8 @@
 - Dishwasher
 - DivideSelection1
 - DivideSelection2
+- DivideThree
+- Divide
 - DocSearchAlt
 - DocSearch
 - DocStarAlt
@@ -333,6 +343,7 @@
 - DownloadSquareOutline
 - Download
 - DragHandGesture
+- Drag
 - Drawer
 - Dribbble
 - DroneChargeFull
@@ -553,6 +564,8 @@
 - Home
 - HorizDistributionLeft
 - HorizDistributionRight
+- HorizontalMerge
+- HorizontalSplit
 - HospitalSign
 - Hospital
 - HotAirBalloon
@@ -769,10 +782,14 @@
 - Package
 - Packages
 - Pacman
+- PageDown
 - PageEdit
 - PageFlip
+- PageLeft
+- PageRight
 - PageSearch
 - PageStar
+- PageUp
 - Page
 - Palette
 - PanoramaEnlarge
@@ -784,6 +801,7 @@
 - PasswordError
 - PasswordPass
 - PasteClipboard
+- PathArrow
 - PauseOutline
 - PauseWindow
 - PcCheck
@@ -983,6 +1001,7 @@
 - ShoppingCode
 - ShortPantsAlt
 - ShortPants
+- Shortcut
 - Shuffle
 - SidebarCollapse
 - SidebarExpand
@@ -1137,6 +1156,8 @@
 - Vegan
 - VerifiedBadge
 - VerifiedUser
+- VerticalMerge
+- VerticalSplit
 - VideoCameraOff
 - VideoCamera
 - ViewColumns2

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "gh-pages": "^4.0.0",
-    "iconoir": "5.3.2",
+    "iconoir": "5.4.0",
     "rollup": "^2.79.1",
     "svelte": "^3.52.0",
     "svelte-check": "^2.9.2",

--- a/test/Icons.test.svelte
+++ b/test/Icons.test.svelte
@@ -7,6 +7,7 @@
     AppleWallet,
     Bed,
     FastArrowBottom,
+    Divide,
   } from "../lib";
   import AddPage from "../lib/AddPage.svelte";
 </script>
@@ -19,3 +20,4 @@
 <AppleWallet fill="red" />
 <Bed />
 <FastArrowBottom />
+<Divide />

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,10 +522,10 @@ html-minifier@^4.0.0:
     relateurl "^0.2.7"
     uglify-js "^3.5.1"
 
-iconoir@5.3.2:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-5.3.2.tgz#bd74a542bc499282c067740076f76d1153f4d4df"
-  integrity sha512-om9zHIRaoRs4XUXq11+/RB7lucY8eiz2nX1+DV0VjefMDAlncKctygz6Z/11lQDkISuyaBcbYDpJQvFcaEGvdg==
+iconoir@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-5.4.0.tgz#ecbfe373654fedd99d2ff57777132fd3ceab83bc"
+  integrity sha512-oxTLDK6pSEd52KM+7PI8hUsV2FgRWIUwNLFTIAs2g7/ZTU1mWYDPRXEyNyKm1BW6+TDtSsrsjvER6jzQ4CyyKw==
 
 import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
- upgrade `iconoir` to [v5.4.0](https://github.com/iconoir-icons/iconoir/releases/tag/v5.4) (net +21 icons)