### PR TITLE
feat(deps-dev): upgrade `iconoir` 5.4.0 -> 5.5.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 1210 total icons
+> 1236 total icons
 
 ## Icons
 
@@ -110,6 +110,8 @@
 - ArrowUpCircled
 - ArrowUp
 - Asana
+- AtSignCircle
+- AtSign
 - Atom
 - Attachment
 - AugmentedReality
@@ -175,6 +177,10 @@
 - BoxIso
 - Box
 - BoxingGlove
+- BrainElectricity
+- BrainResearch
+- BrainWarning
+- Brain
 - BreadSlice
 - BrightnessWindow
 - Brightness
@@ -194,8 +200,12 @@
 - Calendar
 - Camera
 - Cancel
+- CandlestickChart
 - CarOutline
 - Carbon
+- CardIssue
+- CardLocked
+- CardSecurity
 - CardWallet
 - CartAlt
 - Cart
@@ -258,6 +268,7 @@
 - Consumable
 - ControlSlider
 - Cookie
+- Cooling
 - Copy
 - Copyright
 - CornerBottomLeft
@@ -270,6 +281,7 @@
 - CreativeCommons
 - CreditCard2
 - CreditCard
+- CreditCards
 - Crib
 - CropRotateBl
 - CropRotateBr
@@ -315,6 +327,7 @@
 - DesignPencil
 - Desk
 - Dialpad
+- Diameter
 - DiceFive
 - DiceFour
 - DiceOne
@@ -329,6 +342,7 @@
 - DivideSelection2
 - DivideThree
 - Divide
+- Dna
 - DocSearchAlt
 - DocSearch
 - DocStarAlt
@@ -420,7 +434,6 @@
 - Facebook
 - Facetime
 - Farm
-- FastArrowBottom
 - FastArrowDownBox
 - FastArrowDown
 - FastArrowLeftBox
@@ -513,6 +526,7 @@
 - GoogleOne
 - Google
 - Gps
+- GraduationCap
 - GraphDown
 - GraphUp
 - GreenBus
@@ -540,6 +554,7 @@
 - HealthShield
 - Healthcare
 - Heart
+- Heating
 - HeavyRain
 - Heptagon
 - HerSlips
@@ -574,6 +589,7 @@
 - Hydrogen
 - Iconoir
 - Import
+- Inclination
 - Industry
 - Infinite
 - InfoEmpty
@@ -671,6 +687,7 @@
 - MapsTurnLeft
 - MapsTurnRight
 - MaskSquare
+- MastercardCard
 - MathBook
 - Maximize
 - Medal
@@ -695,6 +712,7 @@
 - MicSpeaking
 - MicWarning
 - Mic
+- Microscope
 - Minus1
 - MinusHexagon
 - MinusPinAlt
@@ -804,6 +822,7 @@
 - PathArrow
 - PauseOutline
 - PauseWindow
+- Paypal
 - PcCheck
 - PcFirewall
 - PcMouse
@@ -875,6 +894,8 @@
 - QuestionSquareOutline
 - QuoteMessage
 - Quote
+- Radiation
+- Radius
 - Rain
 - RawFormat
 - ReceiveDollars
@@ -929,6 +950,7 @@
 - RoundedMirror
 - RssFeedSquared
 - RssFeed
+- RubikCube
 - RulerAdd
 - RulerCombine
 - RulerRemove
@@ -1158,6 +1180,7 @@
 - VerifiedUser
 - VerticalMerge
 - VerticalSplit
+- Vials
 - VideoCameraOff
 - VideoCamera
 - ViewColumns2
@@ -1203,14 +1226,17 @@
 - Wrench
 - Wristwatch
 - Www
+- XCoordinate
 - XboxA
 - XboxB
 - XboxX
 - XboxY
 - XrayView
+- YCoordinate
 - YenSquare
 - Yen
 - Yoga
 - Youtube
+- ZCoordinate
 - ZoomIn
 - ZoomOut

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "gh-pages": "^4.0.0",
-    "iconoir": "5.4.0",
+    "iconoir": "5.5.0",
     "rollup": "^2.79.1",
     "svelte": "^3.54.0",
     "svelte-check": "^2.10.1",

--- a/test/Icons.test.svelte
+++ b/test/Icons.test.svelte
@@ -6,7 +6,7 @@
     Fishing,
     AppleWallet,
     Bed,
-    FastArrowBottom,
+    AtSign,
     Divide,
   } from "../lib";
   import AddPage from "../lib/AddPage.svelte";
@@ -19,5 +19,5 @@
 <AddPage width="30" />
 <AppleWallet fill="red" />
 <Bed />
-<FastArrowBottom />
+<AtSign />
 <Divide />

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,10 +522,10 @@ html-minifier@^4.0.0:
     relateurl "^0.2.7"
     uglify-js "^3.5.1"
 
-iconoir@5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-5.4.0.tgz#ecbfe373654fedd99d2ff57777132fd3ceab83bc"
-  integrity sha512-oxTLDK6pSEd52KM+7PI8hUsV2FgRWIUwNLFTIAs2g7/ZTU1mWYDPRXEyNyKm1BW6+TDtSsrsjvER6jzQ4CyyKw==
+iconoir@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-5.5.0.tgz#12a464a07f93bf1f017e38f30329fb9f1ad4b2d9"
+  integrity sha512-J4H+tUk9b+Y6t/EEJDGeZVFB89ma4wOb1hHpr3UR+3J8mVHTs3nR5YDbEYI4FaS0fwTFyM9HLk3yBWUmo4IEbg==
 
 import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
- upgrade `iconoir` to [v5.5.0](https://github.com/iconoir-icons/iconoir/releases/tag/v5.5) (net +26 icons)