### PR TITLE
feat(deps-dev): upgrade `iconoir` 6.0.0 -> 6.2.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 1235 total icons
+> 1259 total icons
 
 ## Icons
 
@@ -47,6 +47,7 @@
 - AddToCart
 - AddUser
 - AfricanTree
+- Agile
 - AirConditioner
 - AirplaneHelix45deg
 - AirplaneHelix
@@ -183,6 +184,8 @@
 - BrainWarning
 - Brain
 - BreadSlice
+- BrightCrown
+- BrightStar
 - BrightnessWindow
 - Brightness
 - BubbleDownload
@@ -198,6 +201,8 @@
 - Bus
 - CableTag
 - Calculator
+- CalendarMinus
+- CalendarPlus
 - Calendar
 - Camera
 - Cancel
@@ -261,6 +266,7 @@
 - ColorPickerEmpty
 - ColorPicker
 - Combine
+- Community
 - CompactDisc
 - Compass
 - CompressLines
@@ -288,6 +294,8 @@
 - CropRotateTl
 - CropRotateTr
 - Crop
+- CrownCircle
+- Crown
 - Css3
 - CursorPointer
 - CutAlt
@@ -500,11 +508,13 @@
 - GifFormat
 - Gift
 - GitBranch
+- GitCherryPickCommit
 - GitCommand
 - GitCommit
 - GitCompare
 - GitFork
 - GitMerge
+- GitPullRequestClosed
 - GitPullRequest
 - GithubCircle
 - Github
@@ -615,6 +625,7 @@
 - KeyAltPlus
 - KeyAltRemove
 - KeyAlt
+- KeyCommand
 - KeyframeAlignCenter
 - KeyframeAlignHorizontal
 - KeyframeAlignVertical
@@ -635,6 +646,7 @@
 - LeaderboardStar
 - Leaderboard
 - Leaf
+- Learning
 - LeftRoundArrow
 - Lens
 - Lifebelt
@@ -697,6 +709,7 @@
 - MediaVideoFolder
 - MediaVideoList
 - MediaVideo
+- MediumPriority
 - Medium
 - Megaphone
 - MenuScale
@@ -781,6 +794,7 @@
 - Octagon
 - OffTag
 - OilIndustry
+- Okrs
 - OnTag
 - OneFingerSelectHandGesture
 - OnePointCircle
@@ -880,6 +894,7 @@
 - Potion
 - Pound
 - PrecisionTool
+- Presentation
 - PrinterAlt
 - Printer
 - PrintingPage
@@ -1027,6 +1042,7 @@
 - SidebarExpand
 - SigmaFunction
 - SimpleCart
+- SineWave
 - SingleTapGesture
 - Skateboard
 - Skateboarding
@@ -1058,6 +1074,7 @@
 - Sphere
 - Spiral
 - SpockHandGesture
+- SquareWave
 - Square
 - Stackoverflow
 - StarDashed
@@ -1068,6 +1085,7 @@
 - StatsDownSquare
 - StatsReport
 - StatsUpSquare
+- Strategy
 - Stretching
 - Stroller
 - StyleBorder
@@ -1089,6 +1107,7 @@
 - SwitchOn
 - SystemRestart
 - SystemShut
+- TShirt
 - Table2Columns
 - TableRows
 - Table
@@ -1168,8 +1187,11 @@
 - UserBag
 - UserCart
 - UserCircle
+- UserCrown
+- UserLove
 - UserScan
 - UserSquare
+- UserStar
 - User
 - VeganCircle
 - VeganSquare
@@ -1181,6 +1203,7 @@
 - Vials
 - VideoCameraOff
 - VideoCamera
+- VideoProjector
 - ViewColumns2
 - ViewColumns3
 - ViewGrid
@@ -1221,6 +1244,7 @@
 - Wifi
 - Wind
 - Windows
+- WomenTShirt
 - WrapText
 - Wrench
 - Wristwatch

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "gh-pages": "^4.0.0",
-    "iconoir": "6.0.0",
+    "iconoir": "6.2.0",
     "rollup": "^3.9.1",
     "svelte": "^3.55.0",
     "svelte-check": "^3.0.1",

--- a/test/Icons.test.svelte
+++ b/test/Icons.test.svelte
@@ -9,6 +9,7 @@
     Bed,
     AtSign,
     Divide,
+    Agile,
   } from "../lib";
   import AddPage from "../lib/AddPage.svelte";
 </script>
@@ -23,3 +24,4 @@
 <Bed />
 <AtSign />
 <Divide />
+<Agile />

--- a/yarn.lock
+++ b/yarn.lock
@@ -530,10 +530,10 @@ html-minifier@^4.0.0:
     relateurl "^0.2.7"
     uglify-js "^3.5.1"
 
-iconoir@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-6.0.0.tgz#1d1f18439456c6bbda128e52fb703794e36a5936"
-  integrity sha512-ghej+WGy2rSC+IVGPi39596p1uAFh9rdAElFIYdT0CdMOtSd7uVjWsalPFo25dhTvtoxrS3iguao28qS2JCUPw==
+iconoir@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-6.2.0.tgz#fe8a3b538421bb1cab24ff4d023535ca55423266"
+  integrity sha512-N66dDd6MjpYFMpyzs+c91dHFodFWrtQHpzBJe6qAz5kA8Mt0Qy2PFxYaF3pesZzkTnHrZ6nArSD+EhbfnSImyg==
 
 import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
- upgrade `iconoir` to [v6.2.0](https://github.com/iconoir-icons/iconoir/releases/tag/v6.2) (net +24 icons)