### PR TITLE
feat(deps-dev): upgrade `iconoir` 6.3.0 -> 6.4.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 1305 total icons
+> 1314 total icons
 
 ## Icons
 
@@ -315,6 +315,7 @@
 - Css3
 - CursorPointer
 - CutAlt
+- CutSolidWithCurve
 - Cut
 - Cycling
 - Cylinder
@@ -454,6 +455,7 @@
 - Exclude
 - ExpandLines
 - Expand
+- Extrude
 - EyeAlt
 - EyeClose
 - EyeEmpty
@@ -481,6 +483,7 @@
 - Figma
 - FileNotFound
 - FillColor
+- Fillet3d
 - FilterAlt
 - FilterListCircle
 - FilterList
@@ -694,6 +697,7 @@
 - Lock
 - LockedBook
 - LockedWindow
+- Loft3d
 - LogDenied
 - LogIn
 - LogOut
@@ -867,6 +871,7 @@
 - PasswordError
 - PasswordPass
 - PasteClipboard
+- PatchHoles3d
 - PathArrow
 - PauseWindow
 - Pause
@@ -904,6 +909,7 @@
 - Pin
 - PineTree
 - Pinterest
+- Pipe3d
 - PizzaSlice
 - PlanetAlt
 - PlanetSat
@@ -938,6 +944,7 @@
 - PrivateWifi
 - ProfileCircle
 - Prohibition
+- ProjectCurve3d
 - Puzzle
 - QrCode
 - QuestionMark
@@ -1132,6 +1139,7 @@
 - Suggestion
 - SunLight
 - SvgFormat
+- Sweep3d
 - Swimming
 - SwipeDownGesture
 - SwipeLeftGesture
@@ -1222,6 +1230,7 @@
 - Union
 - Unity5
 - Unity
+- Unjoin3d
 - UpRoundArrow
 - UploadDataWindow
 - UploadSquare

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "gh-pages": "^4.0.0",
-    "iconoir": "6.3.0",
+    "iconoir": "6.4.0",
     "rollup": "^2.79.1",
     "svelte": "^3.55.0",
     "svelte-check": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -530,10 +530,10 @@ html-minifier@^4.0.0:
     relateurl "^0.2.7"
     uglify-js "^3.5.1"
 
-iconoir@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-6.3.0.tgz#7659a93175560009e431eaebe7b4c1e8884a65bf"
-  integrity sha512-3MRcHSZoGCgSeVZ985YeLRu8C7H7lnr+LDQtbe1CbPbq4Tb6lntwkglsn7KwSmyhbjQMEzB0CGGqNa20tQ+N0Q==
+iconoir@6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-6.4.0.tgz#50860ff1c1f4c69b0e727e50d4aacab23a84349b"
+  integrity sha512-G58GRuhI0upMihsIjUwCN2LTeg3UZRtgGsAdmgZBjI7s8pjsZC5hQrOqAY9qELQjBzCfpnP98m4lNWP10wANbQ==
 
 import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
- upgrade `iconoir` to [v6.4.0](https://github.com/iconoir-icons/iconoir/releases/tag/v6.4.0) (net +9 icons)