### PR TITLE
feat(deps-dev): upgrade `iconoir` 6.4.0 -> 6.5.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 1314 total icons
+> 1335 total icons
 
 ## Icons
 
@@ -167,6 +167,8 @@
 - BirthdayCake
 - Bishop
 - Bitbucket
+- BitcoinCircle
+- BitcoinRotateOut
 - BluetoothTag
 - Bluetooth
 - BoldSquare
@@ -225,6 +227,7 @@
 - Carbon
 - CardIssue
 - CardLocked
+- CardReader
 - CardSecurity
 - CardWallet
 - CartAlt
@@ -275,6 +278,8 @@
 - Codepen
 - CoffeeCup
 - Coin
+- CoinsSwap
+- Coins
 - CollageFrame
 - Collapse
 - ColorFilter
@@ -282,6 +287,7 @@
 - ColorPicker
 - ColorWheel
 - Combine
+- Commodity
 - Community
 - CompactDisc
 - Compass
@@ -289,6 +295,7 @@
 - Compress
 - Computer
 - Consumable
+- Contactless
 - ControlSlider
 - Cookie
 - Cooling
@@ -376,6 +383,8 @@
 - DocSearch
 - DocStarAlt
 - DocStar
+- DogecoinCircle
+- DogecoinRotateOut
 - Dollar
 - DomoticIssue
 - Donate
@@ -443,6 +452,8 @@
 - Enlarge
 - Erase
 - ErrorWindow
+- EthereumCircle
+- EthereumRotateOut
 - EuroSquare
 - Euro
 - EvChargeAlt
@@ -578,6 +589,9 @@
 - HalfMoon
 - Hammer
 - HandBrake
+- HandCard
+- HandCash
+- HandContactless
 - Handbag
 - HardDrive
 - Hat
@@ -692,6 +706,8 @@
 - Linux
 - ListSelect
 - List
+- LitecoinCircle
+- LitecoinRotateOut
 - LoadActionFloppy
 - LockKey
 - Lock
@@ -889,6 +905,7 @@
 - PenTablet
 - Pentagon
 - PeopleTag
+- PercentRotateOut
 - PercentageCircle
 - PercentageSquare
 - Percentage
@@ -1012,6 +1029,10 @@
 - Ruler
 - Running
 - Safari
+- SafeArrowLeft
+- SafeArrowRight
+- SafeOpen
+- Safe
 - Sandals
 - SaveActionFloppy
 - SaveFloppyDisk

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "gh-pages": "^4.0.0",
-    "iconoir": "6.4.0",
+    "iconoir": "6.5.0",
     "rollup": "^2.79.1",
     "svelte": "^3.55.0",
     "svelte-check": "^3.0.1",

--- a/test/Icons.test.svelte
+++ b/test/Icons.test.svelte
@@ -11,6 +11,7 @@
     Divide,
     Agile,
     AdobeAfterEffects,
+    CardReader,
   } from "../lib";
   import AddPage from "../lib/AddPage.svelte";
 </script>
@@ -27,3 +28,4 @@
 <Divide />
 <Agile />
 <AdobeAfterEffects />
+<CardReader />

--- a/yarn.lock
+++ b/yarn.lock
@@ -530,10 +530,10 @@ html-minifier@^4.0.0:
     relateurl "^0.2.7"
     uglify-js "^3.5.1"
 
-iconoir@6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-6.4.0.tgz#50860ff1c1f4c69b0e727e50d4aacab23a84349b"
-  integrity sha512-G58GRuhI0upMihsIjUwCN2LTeg3UZRtgGsAdmgZBjI7s8pjsZC5hQrOqAY9qELQjBzCfpnP98m4lNWP10wANbQ==
+iconoir@6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-6.5.0.tgz#a74ea2edd91f44d03b3447f8ecd855638aa68ebe"
+  integrity sha512-/PQF5MegEcxufsnf5XNj8nPeOnt4Sm/3oyt8gncGoOw/dmidOEb/wz4PMjsKGPvNp+t2jziznxbsoBhc8VVcsg==
 
 import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
- upgrade `iconoir` to [v6.5.0](https://github.com/iconoir-icons/iconoir/releases/tag/v6.5.0) (net +21 icons)