### PR TITLE
feat(deps-dev): upgrade `iconoir` 6.5.0 -> 6.8.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 1335 total icons
+> 1350 total icons
 
 ## Icons
 
@@ -12,6 +12,7 @@
 - \_3dArc
 - \_3dBridge
 - \_3dCenterBox
+- \_3dDraftFace
 - \_3dEllipseThreePts
 - \_3dEllipse
 - \_3dPtBox
@@ -86,6 +87,7 @@
 - AppleImac2021Side
 - AppleImac2021
 - AppleMac
+- AppleShortcuts
 - AppleSwift
 - AppleWallet
 - Apple
@@ -121,6 +123,7 @@
 - ArrowUnion
 - ArrowUpCircle
 - ArrowUp
+- ArrowsUpFromLine
 - Asana
 - AtSignCircle
 - AtSign
@@ -259,6 +262,7 @@
 - City
 - CleanWater
 - ClipboardCheck
+- ClockRotateRight
 - Clock
 - ClosedCaptions
 - Closet
@@ -289,8 +293,13 @@
 - Combine
 - Commodity
 - Community
+- CompAlignBottom
+- CompAlignLeft
+- CompAlignRight
+- CompAlignTop
 - CompactDisc
 - Compass
+- Component
 - CompressLines
 - Compress
 - Computer
@@ -320,6 +329,7 @@
 - CrownCircle
 - Crown
 - Css3
+- CubeReplaceFace
 - CursorPointer
 - CutAlt
 - CutSolidWithCurve
@@ -559,6 +569,7 @@
 - Github
 - GitlabFull
 - GlassEmpty
+- GlassFragile
 - GlassHalfAlt
 - GlassHalf
 - Glasses
@@ -604,6 +615,7 @@
 - Headset
 - HealthShield
 - Healthcare
+- HeartArrowDown
 - Heart
 - Heating
 - HeavyRain
@@ -1135,10 +1147,13 @@
 - SoundMin
 - SoundOff
 - Spades
+- Spark
+- Sparks
 - Sphere
 - Spiral
 - SpockHandGesture
 - Spotify
+- SquareCursor
 - SquareWave
 - Square
 - Stackoverflow

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "gh-pages": "^4.0.0",
-    "iconoir": "6.5.0",
+    "iconoir": "6.8.0",
     "rollup": "^2.79.1",
     "svelte": "^3.55.0",
     "svelte-check": "^3.0.1",

--- a/test/Icons.test.svelte
+++ b/test/Icons.test.svelte
@@ -12,6 +12,7 @@
     Agile,
     AdobeAfterEffects,
     CardReader,
+    AppleShortcuts,
   } from "../lib";
   import AddPage from "../lib/AddPage.svelte";
 </script>
@@ -29,3 +30,4 @@
 <Agile />
 <AdobeAfterEffects />
 <CardReader />
+<AppleShortcuts />

--- a/yarn.lock
+++ b/yarn.lock
@@ -530,10 +530,10 @@ html-minifier@^4.0.0:
     relateurl "^0.2.7"
     uglify-js "^3.5.1"
 
-iconoir@6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-6.5.0.tgz#a74ea2edd91f44d03b3447f8ecd855638aa68ebe"
-  integrity sha512-/PQF5MegEcxufsnf5XNj8nPeOnt4Sm/3oyt8gncGoOw/dmidOEb/wz4PMjsKGPvNp+t2jziznxbsoBhc8VVcsg==
+iconoir@6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-6.8.0.tgz#bf947126b58f35e7add63ffdf0fccbdb3a595816"
+  integrity sha512-7Bum/AMEIUDceRBZiJO/je3YRRXck/VeBiQb2nXsEIPdwxF3B+kMI2ToWZ2dI/UtZkHelvr75kRfpGPi7rTKbg==
 
 import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
- upgrade `iconoir` to [v6.8.0](https://github.com/iconoir-icons/iconoir/releases/tag/v6.8.0) (net +15 icons)