### PR TITLE
feat(deps-dev): upgrade `iconoir` 6.10.0 -> 6.11.0

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 1359 total icons
+> 1371 total icons
 
 ## Icons
 
@@ -863,6 +863,16 @@
 - Notes
 - NpmSquare
 - Npm
+- Number0Square
+- Number1Square
+- Number2Square
+- Number3Square
+- Number4Square
+- Number5Square
+- Number6Square
+- Number7Square
+- Number8Square
+- Number9Square
 - NumberedListLeft
 - NumberedListRight
 - Octagon
@@ -969,6 +979,7 @@
 - Pokeball
 - PositionAlign
 - Position
+- Post
 - Potion
 - Pound
 - PrecisionTool
@@ -1218,6 +1229,7 @@
 - TextBox
 - TextSize
 - Text
+- Threads
 - ThreePointsCircle
 - ThreeStars
 - ThumbsDown

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "gh-pages": "^4.0.0",
-    "iconoir": "6.10.0",
+    "iconoir": "6.11.0",
     "rollup": "^2.79.1",
     "svelte": "^4.1.1",
     "svelte-check": "^3.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -599,10 +599,10 @@ html-minifier@^4.0.0:
     relateurl "^0.2.7"
     uglify-js "^3.5.1"
 
-iconoir@6.10.0:
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-6.10.0.tgz#4009adc76e35d859383ee688a3b17ac6cc5d4d01"
-  integrity sha512-nuErohyTJzBSM7w/M8654DR+o4UAXaV8Iz3gRDCv9KD/k+nD3fKqGCr2/SIiNnfU3Tsn4z6ZUgKojkk3yIPUHg==
+iconoir@6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/iconoir/-/iconoir-6.11.0.tgz#99ed6af7a6d96e137c29cc8d057a8d07c0030490"
+  integrity sha512-68YIHDwpJojMN4Qz0YnaIVzWudcsSLwWc2MmxxvT6r4oL96kCTAuZwQJHv8Z2ZrTCW8acI4dfETmo4X+Q36rfA==
 
 import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
- upgrade `iconoir` to [v6.11.0](https://github.com/iconoir-icons/iconoir/releases/tag/v6.11.0) (net +12 icons)